### PR TITLE
piping stderr into stdout broke curl

### DIFF
--- a/GHMarkdownPreview.py
+++ b/GHMarkdownPreview.py
@@ -25,7 +25,7 @@ def call_exe(command, dir):
         command,
         cwd=dir,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         universal_newlines=True)
     stdout, stderr = process.communicate()
     exit_code = process.wait()


### PR DESCRIPTION
This caused download statistics from curl to be displayed at the top of the preview.
