### PR TITLE
Update Default (OSX).sublime-keymap

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
     {
-      "keys": ["ctrl+shift+g"],
+      "keys": ["super+f12"],
       "command": "github_markdown_preview",
       "context": [ { "key": "selector", "operator": "equal", "operand": "text.html.markdown" } ]
     }


### PR DESCRIPTION
Change keybinding to "super+f12".  At least in Sublime Text 3 build 3083, "ctrl+shift+g" is already mapped to "find_all_under" in OSX, and "f12" by itself is already mapped to "goto_definition".

Windows and Linux both apparently use "alt+f3" for that same command, so no need to change it for those operating systems unless you want consistency.
