### PR TITLE
Added a <base> tag to the generated preview

### DIFF
--- a/GHMarkdownPreview.py
+++ b/GHMarkdownPreview.py
@@ -5,6 +5,7 @@ import tempfile
 import webbrowser
 import json
 import subprocess
+import urllib.parse
 
 # The python package included with sublime text for Linux is missing the ssl
 # module (for technical reasons), so this import will fail. But, we can use the
@@ -64,9 +65,11 @@ class github_markdown_preview_command(sublime_plugin.TextCommand):
             selection = sublime.Region(0, self.view.size())
             repoName = get_github_repo_name(self.view.file_name())
             path = os.path.dirname(self.view.file_name())
+            path_encoded = urllib.parse.quote(path)
+            header = "<head><base href='file://%s/'/></head>" % path_encoded
             html = generate_preview(self.view.substr(selection), repoName)
             temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.html')
-            temp_file.write(("<head><base href='file://%s/'/></head>" % path).encode("utf-8"))
+            temp_file.write(header.encode("utf-8"))
             temp_file.write(html)
             temp_file.close()
             webbrowser.open("file://" + temp_file.name)

--- a/GHMarkdownPreview.py
+++ b/GHMarkdownPreview.py
@@ -63,8 +63,10 @@ class github_markdown_preview_command(sublime_plugin.TextCommand):
         try:
             selection = sublime.Region(0, self.view.size())
             repoName = get_github_repo_name(self.view.file_name())
+            path = os.path.dirname(self.view.file_name())
             html = generate_preview(self.view.substr(selection), repoName)
             temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.html')
+            temp_file.write(("<head><base href='file://%s/'/></head>" % path).encode("utf-8"))
             temp_file.write(html)
             temp_file.close()
             webbrowser.open("file://" + temp_file.name)


### PR DESCRIPTION
Quick and dirty improvement to allow you to preview inline images with relative paths.

For example, something like `![Board Image](board.jpg?raw=true)`in a readme.md file.

Normally these relative links would not work since the rest of your repo is not copied to the temporary folder where the html file is built.  A <base> tag and a header section is added to the generated HTML temporary file to allow the browser to find files in the project directory.

Take it or leave it.  Since I use GitHubMarkdownPreview to test my readme files, this comes in handy.

Works for me, but not extensively tested.

Thanks.